### PR TITLE
Update setup script

### DIFF
--- a/setup/c9setup.sh
+++ b/setup/c9setup.sh
@@ -7,4 +7,4 @@ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O Mi
 bash Miniconda3-latest-Linux-x86_64.sh -b
 export PATH="$HOME/miniconda3/bin:$PATH"
 echo 'export PATH=$HOME/miniconda3/bin:$PATH' >> ~/.bashrc
-conda install jupyter notebook -y
+conda install jupyter notebook --yes

--- a/setup/c9setup.sh
+++ b/setup/c9setup.sh
@@ -9,6 +9,6 @@ rm Miniconda3-latest-Linux-x86_64.sh
 export PATH="$HOME/miniconda3/bin:$PATH"
 echo 'export PATH=$HOME/miniconda3/bin:$PATH' >> ~/.bashrc
 conda install jupyter notebook --yes
-makedir ~/.jupyter
+mkdir ~/.jupyter
 touch ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.token = u''" >> ~/.jupyter/jupyter_notebook_config.py

--- a/setup/c9setup.sh
+++ b/setup/c9setup.sh
@@ -5,6 +5,10 @@ then
 fi
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b
+rm Miniconda3-latest-Linux-x86_64.sh
 export PATH="$HOME/miniconda3/bin:$PATH"
 echo 'export PATH=$HOME/miniconda3/bin:$PATH' >> ~/.bashrc
 conda install jupyter notebook --yes
+makedir ~/.jupyter
+touch ~/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.token = u''" >> ~/.jupyter/jupyter_notebook_config.py

--- a/setup/c9setup.sh
+++ b/setup/c9setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-if [ -d $HOME/anaconda2 ]
+if [ -d $HOME/miniconda3 ]
 then
-    rm -rf $HOME/anaconda2
+    rm -rf $HOME/miniconda3
 fi
-wget http://repo.continuum.io/archive/Anaconda2-4.0.0-Linux-x86_64.sh -O Anaconda2-4.0.0-Linux-x86_64.sh
-bash Anaconda2-4.0.0-Linux-x86_64.sh -b
-export PATH="$HOME/anaconda2/bin:$PATH"
-echo 'export PATH=$HOME/anaconda2/bin:$PATH' >> ~/.bashrc
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh -b
+export PATH="$HOME/miniconda3/bin:$PATH"
+echo 'export PATH=$HOME/miniconda3/bin:$PATH' >> ~/.bashrc && source ~/.bashrc

--- a/setup/c9setup.sh
+++ b/setup/c9setup.sh
@@ -6,4 +6,5 @@ fi
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -b
 export PATH="$HOME/miniconda3/bin:$PATH"
-echo 'export PATH=$HOME/miniconda3/bin:$PATH' >> ~/.bashrc && source ~/.bashrc
+echo 'export PATH=$HOME/miniconda3/bin:$PATH' >> ~/.bashrc
+conda install jupyter notebook -y


### PR DESCRIPTION
Updated to miniconda3 and install jupyter notebook.

usage is `. ./setup/c9setup.sh`

then when we're ready to use the notebook we can `jupyter notebook --port=8080 --ip=* --no-browser` and direct the users to the application link of their workspace